### PR TITLE
fix: support base is ./

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -130,8 +130,15 @@ ${match}`);
         return script.replace("nomodule", "");
       if (id === "vite-legacy-entry") {
         const srcMatch = script.match(srcReg);
-        const src = (srcMatch == null ? void 0 : srcMatch[2]) || "";
-        return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import('${src}')`)}`;
+        let src = (srcMatch == null ? void 0 : srcMatch[2]) || "";
+        const isHttpReg = /^(https?):\/\//;
+        if (isHttpReg.test(src)) {
+          return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import('${src}')`)}`;
+        }
+        if (src.startsWith(".")) {
+          src = src.substring(1);
+        }
+        return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import(global.legacyQiankun[name].publicPath + '${src}')`)}`;
       }
       return replaceScript(script);
     }).replace("<head>", (match) => `${match}

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -105,8 +105,15 @@ ${match}`);
         return script.replace("nomodule", "");
       if (id === "vite-legacy-entry") {
         const srcMatch = script.match(srcReg);
-        const src = (srcMatch == null ? void 0 : srcMatch[2]) || "";
-        return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import('${src}')`)}`;
+        let src = (srcMatch == null ? void 0 : srcMatch[2]) || "";
+        const isHttpReg = /^(https?):\/\//;
+        if (isHttpReg.test(src)) {
+          return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import('${src}')`)}`;
+        }
+        if (src.startsWith(".")) {
+          src = src.substring(1);
+        }
+        return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import(global.legacyQiankun[name].publicPath + '${src}')`)}`;
       }
       return replaceScript(script);
     }).replace("<head>", (match) => `${match}

--- a/index.ts
+++ b/index.ts
@@ -129,9 +129,16 @@ export const legacyQiankun = ({ name }: PluginOptions): Plugin[] => {
 
         if (id === 'vite-legacy-entry') {
           const srcMatch = script.match(srcReg)
-          const src = srcMatch?.[2] || ''
+          let src = srcMatch?.[2] || ''
 
-          return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import('${src}')`)}`
+          const isHttpReg = /^(https?):\/\//
+          if(isHttpReg.test(src)) {
+            return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import('${src}')`)}`;
+          }
+          if(src.startsWith(".")){
+            src = src.substring(1)
+          }
+          return `${createScriptStr(`global.legacyQiankun[name].dynamicImport = System.import(global.legacyQiankun[name].publicPath + '${src}')`)}`;
         }
 
         return replaceScript(script)


### PR DESCRIPTION
当base设置为./的时候,  
```ts
export default {
  base: base ? `./` : '/',
  build: {
    outDir: '../dist/vue3'
  },
 ...
}

```
打包出来之后 System.import 路径如下

![image](https://user-images.githubusercontent.com/14543369/226874608-ac56a602-5273-4c2a-9dbd-55fa07bde6e8.png)

导致实际加载的路径变成了主引应用的

![image](https://user-images.githubusercontent.com/14543369/226875468-ac5c41ba-d565-489c-8102-f353c32f6943.png)

调整之后给路径加上 publicPath， 可以正常加载子应用

![image](https://user-images.githubusercontent.com/14543369/226875699-a770bf09-8f7c-45d6-b8ff-1352dadac43c.png)

